### PR TITLE
chore: Speed up CI by using binary installer for cargo-near

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,13 +34,12 @@ jobs:
           run:
               sudo apt update -y &&
               sudo apt install -y pkg-config libusb-1.0-0-dev libftdi1-dev libudev-dev
-        - uses: taiki-e/install-action@v2
-          with:
-            tool: cargo-near
+        - name: install cargo-near
+          if: steps.git-diff.outputs.diff
+          run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/latest/download/cargo-near-installer.sh | sh
         - name: clippy 
           if: steps.git-diff.outputs.diff
-          run: |
-                cargo clippy --release -- -D warnings -A clippy::too_many_arguments
+          run: cargo clippy --release -- -D warnings -A clippy::too_many_arguments
         - name: build bot
           if: steps.git-diff.outputs.diff
           run: cargo build --release


### PR DESCRIPTION
cargo-binstall does not work for cargo-near for some reason, so I switched to curl-installer

@race-of-sloths