### PR TITLE
feat: health check for updaters

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,4 +45,4 @@ jobs:
           run: cargo build --release
         - name: build contract
           if: steps.git-diff.outputs.diff
-          run: cd contract && cargo near build
+          run: cd contract && cargo near build non-reproducible-wasm

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.86.0"
 components = ["rustfmt", "rust-src", "rust-analyzer"]
 targets = ["wasm32-unknown-unknown"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.86.0"
-components = ["rustfmt", "rust-src", "rust-analyzer"]
+components = ["rustfmt", "rust-src", "rust-analyzer", "clippy"]
 targets = ["wasm32-unknown-unknown"]

--- a/server/src/contract_pull.rs
+++ b/server/src/contract_pull.rs
@@ -185,7 +185,7 @@ pub fn stage(client: NearClient, sleep_duration: Duration, atomic_bool: Arc<Atom
                 while atomic_bool.load(std::sync::atomic::Ordering::Relaxed) {
                     interval.tick().await;
 
-                    let _ = health_monitor.im_alive("Contract Updater");
+                    health_monitor.im_alive("Contract Updater");
 
                     // Execute a query of some kind
                     if let Err(e) = fetch_and_store_all_data(&telegram, &near_client, &db).await {

--- a/server/src/github_pull.rs
+++ b/server/src/github_pull.rs
@@ -241,7 +241,7 @@ pub fn stage(
                             while atomic_bool.load(std::sync::atomic::Ordering::Relaxed) {
                                 interval.tick().await;
 
-                                let _ = health_monitor.im_alive("GitHub Updater");
+                                health_monitor.im_alive("GitHub Updater");
 
                                 if let Err(e) =
                                     fetch_github_data(&telegram, &github_client, &db).await

--- a/server/src/health_monitor.rs
+++ b/server/src/health_monitor.rs
@@ -1,0 +1,42 @@
+use rocket::tokio::sync::mpsc;
+use shared::telegram::TelegramSubscriber;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+pub struct HealthMonitor {
+    sender: mpsc::UnboundedSender<String>,
+}
+
+impl HealthMonitor {
+    pub fn new(telegram: Arc<TelegramSubscriber>) -> Self {
+        let (sender, mut receiver) = mpsc::unbounded_channel::<String>();
+
+        rocket::tokio::spawn(async move {
+            let mut map: HashMap<String, Instant> = HashMap::new();
+            let mut interval = rocket::tokio::time::interval(Duration::from_secs(15));
+            loop {
+                rocket::tokio::select! {
+                    _ = interval.tick() => {
+                        for (task_name, last_heartbeat) in &map {
+                            if last_heartbeat.elapsed() > Duration::from_secs(600) { // 10 minutes
+                                crate::error(&telegram, &format!("🚨 No health reports for {} for 10 minutes - shutting down application", task_name));
+                                // Probably, it should be a more elegant way to do this, but we will crash the app for now to restart it
+                                std::process::exit(1);
+                            }
+                        }
+                    }
+                    Some(task_name) = receiver.recv() => {
+                        map.insert(task_name, Instant::now());
+                    }
+                }
+            }
+        });
+
+        Self { sender }
+    }
+
+    pub fn im_alive(&self, task_name: &str) {
+        let _ = self.sender.send(task_name.to_string());
+    }
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -5,6 +5,7 @@ use shared::telegram::TelegramSubscriber;
 pub mod contract_pull;
 pub mod db;
 pub mod github_pull;
+pub mod health_monitor;
 pub mod svg;
 pub mod types;
 pub mod weekly_stats;


### PR DESCRIPTION
This is a pretty hacky solution to restart the app after one of the updaters crashed.

It's far from ideal, but I'm not sure why the contract updater panicked before. As Fly.io stores logs for only a couple of hours, it's hard to detect the issue. This will allow us to get back to work and luckily to identify the issue once we get notification and get some logging.